### PR TITLE
fix: divide equals number of targets

### DIFF
--- a/go/grpshuffle_server/lib/server.go
+++ b/go/grpshuffle_server/lib/server.go
@@ -33,7 +33,7 @@ func (s *Server) Shuffle(ctx context.Context, req *grpshuffle.ShuffleRequest) (*
 		})
 	}
 
-	if req.Divide >= uint64(len(req.Targets)) {
+	if req.Divide > uint64(len(req.Targets)) {
 		return nil, status.Errorf(codes.InvalidArgument, "Must have `divide` >= `targets` num.")
 	}
 

--- a/go/grpshuffle_server/lib/server_test.go
+++ b/go/grpshuffle_server/lib/server_test.go
@@ -99,6 +99,24 @@ func TestServer_Shuffle(t *testing.T) {
 			},
 		},
 		{
+			name:   "Split same targets.",
+			fields: fields{UnimplementedComputeServer: grpshuffle.UnimplementedComputeServer{}},
+			args: args{
+				ctx: context.Background(),
+				req: &grpshuffle.ShuffleRequest{
+					Targets:    []string{"a", "b"},
+					Divide:     2,
+					Sequential: true,
+				},
+			},
+			want: &grpshuffle.ShuffleResponse{
+				Combinations: []*grpshuffle.Combination{
+					{Targets: []string{"a"}},
+					{Targets: []string{"b"}},
+				},
+			},
+		},
+		{
 			name:   "Not split.",
 			fields: fields{UnimplementedComputeServer: grpshuffle.UnimplementedComputeServer{}},
 			args: args{


### PR DESCRIPTION
```
❯ ./grpshuffle_client shuffle --no-tls -d 2 hoge fuga
2023/03/05 01:12:30 rpc error: code = InvalidArgument desc = Must have `divide` >= `targets` num.
```